### PR TITLE
fix: Added floating docker image tag for the python version

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -27,4 +27,6 @@ jobs:
           file: pymonik_worker/Dockerfile
           push: true
           build-args: "USE_PYTHON_VERSION=${{ matrix.python_version }}"
-          tags: dockerhubaneo/harmonic_snake:python-${{ matrix.python_version }}-${{github.ref_name}}
+          tags: |
+            dockerhubaneo/harmonic_snake:python-${{ matrix.python_version }}-${{ github.ref_name }}
+            dockerhubaneo/harmonic_snake:python-${{ matrix.python_version }}


### PR DESCRIPTION
This would allow us to just specify the Python version in the docker image tag of PymoniK and it'd automatically use the latest available version of PymoniK.