### PR TITLE
feat: Added dynamic versioning based on git tag

### DIFF
--- a/pymonik/pyproject.toml
+++ b/pymonik/pyproject.toml
@@ -1,10 +1,13 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
 [project]
 name = "pymonik"
-version = "0.1.6"
+dynamic = ["version"]
 description = "Lightweight Distributed Computing Framework"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pymonik/src/pymonik/__init__.py
+++ b/pymonik/src/pymonik/__init__.py
@@ -1,8 +1,15 @@
+import importlib.metadata
+
 from .core import Pymonik, Task, task
 from .context import PymonikContext
 from .results import ResultHandle, MultiResultHandle
 from .worker import run_pymonik_worker
 from armonik.common import TaskOptions
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"  # Fallback for development mode
 
 __all__ = [
     "Pymonik",


### PR DESCRIPTION
Removed the need to manually bump the version of PymoniK. 
It'll use the version specified via the git tag (ex: v0.1.2, so v followed by a semantic version) when the workflows get executed. 