### PR TITLE
fix: Fixed problem with dynamic versioning failing docker build

### DIFF
--- a/pymonik/pyproject.toml
+++ b/pymonik/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
+variable = "PYMONIK_BUILD_VERSION"
 
 [project]
 name = "pymonik"

--- a/pymonik_worker/Dockerfile
+++ b/pymonik_worker/Dockerfile
@@ -10,17 +10,21 @@ RUN groupadd --gid 5000 armonikuser && \
     mkdir /cache && \
     chown armonikuser: /cache && \
     chown -R armonikuser: /app 
+    
+
+COPY --chown=armonikuser:armonikuser pymonik /pymonik 
 
 USER armonikuser
 
-COPY pymonik /pymonik 
     
 RUN echo "Writing Python version: $USE_PYTHON_VERSION" && echo "$USE_PYTHON_VERSION" >> .python-version
 RUN cat .python-version 
 
 COPY pymonik_worker/pyproject.toml . 
 
-# We can preinstall packages this way (this is what I meant the other day so that startup is immediate)
+RUN sed -i 's/source = "uv-dynamic-versioning"/source = "env"/' /pymonik/pyproject.toml
+ENV PYMONIK_BUILD_VERSION="0.0.0"
+
 RUN uv sync 
 
 # Copy application code


### PR DESCRIPTION
Docker build failed because it couldn't use `uv-dynamic-versioning`. Made it so the docker image uses version 0.0.0 of PymoniK (will need to change to workflow to maybe pass in the git tag instead)