### PR TITLE
feat: Added polling based result waiting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,8 +39,8 @@ def add(a,b):
     return a+b
 
 with PymoniK():
-    my_constant = get_constant()
-    results = add.map_invoke([(my_constant(), i) for i in range(32)])
+    my_constant = get_constant.invoke()
+    results = add.map_invoke([(my_constant, i) for i in range(32)])
     sum_task = Task(sum)
     remote_partial_result = sum_task.invoke(results[:16])
     local_partial_result = sum_task(results[16:].wait().get())

--- a/pymonik/src/pymonik/results.py
+++ b/pymonik/src/pymonik/results.py
@@ -20,8 +20,8 @@ class ResultHandle(Generic[T]):
                 "Cannot wait for result in worker context. Use the client context instead."
             )
         try:
-            self._pymonik._events_client.wait_for_result_availability(
-                self.result_id, self.session_id
+            self._pymonik._wait_for_results_availability(
+                self.session_id, [self.result_id]
             )
             return self
         except Exception as e:
@@ -91,8 +91,8 @@ class MultiResultHandle:
 
         result_ids = [handle.result_id for handle in self.result_handles]
         try:
-            self._pymonik._events_client.wait_for_result_availability(
-                result_ids, self.session_id
+            self._pymonik._wait_for_results_availability(
+                self.session_id, result_ids
             )
             return self
         except Exception as e:


### PR DESCRIPTION
In cases where the event client is not available, you can optionally disable it and switch to a polling based approach when waiting for results.