### PR TITLE
fix: override target name no longer necessary

### DIFF
--- a/pymonik/src/pymonik/utils.py
+++ b/pymonik/src/pymonik/utils.py
@@ -24,7 +24,6 @@ def create_grpc_channel(
         # Create grpc channel with tls
         channel = create_channel(
             cleaner_endpoint,
-            options=(("grpc.ssl_target_name_override", "armonik.local"),),
             certificate_authority=certificate_authority,
             client_certificate=client_certificate,
             client_key=client_key,


### PR DESCRIPTION
PR https://github.com/aneoconsulting/ArmoniK.Infra/pull/248 fixes the certificate generation so using the `grpc.ssl_target_name_override` is not longer required. 